### PR TITLE
A Visual Studio registry search feature

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,124 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+###############################
+# Core EditorConfig Options   #
+###############################
+root = true
+# All files
+[*]
+indent_style = space
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+###############################
+# VB Coding Conventions       #
+###############################
+[*.vb]
+# Modifier preferences
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -6,6 +6,12 @@ root = true
 # All files
 [*]
 indent_style = space
+[*.xaml]
+indent_style = space
+indent_size = 4
+[*.csproj]
+indent_style = space
+indent_size = 2
 # Code files
 [*.{cs,csx,vb,vbx}]
 indent_size = 4

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -18,10 +18,10 @@ charset = utf-8-bom
 # Organize usings
 dotnet_sort_system_directives_first = true
 # this. preferences
-dotnet_style_qualification_for_field = false:silent
-dotnet_style_qualification_for_property = false:silent
-dotnet_style_qualification_for_method = false:silent
-dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_field = true:silent
+dotnet_style_qualification_for_property = true:silent
+dotnet_style_qualification_for_method = true:silent
+dotnet_style_qualification_for_event = true:silent
 # Language keywords vs BCL types preferences
 dotnet_style_predefined_type_for_locals_parameters_members = true:silent
 dotnet_style_predefined_type_for_member_access = true:silent
@@ -62,9 +62,9 @@ dotnet_naming_symbols.constant_fields.required_modifiers          = const
 ###############################
 [*.cs]
 # var preferences
-csharp_style_var_for_built_in_types = true:silent
-csharp_style_var_when_type_is_apparent = true:silent
-csharp_style_var_elsewhere = true:silent
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = false:silent
+csharp_style_var_elsewhere = false:silent
 # Expression-bodied members
 csharp_style_expression_bodied_methods = false:silent
 csharp_style_expression_bodied_constructors = false:silent
@@ -116,9 +116,3 @@ csharp_space_between_method_call_empty_parameter_list_parentheses = false
 # Wrapping preferences
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
-###############################
-# VB Coding Conventions       #
-###############################
-[*.vb]
-# Modifier preferences
-visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion

--- a/src/Commands/ShowRegistryExplorer.cs
+++ b/src/Commands/ShowRegistryExplorer.cs
@@ -13,11 +13,11 @@ namespace RegistryExplorer
     {
         public static async Task InitializeAsync(AsyncPackage package)
         {
-            var commandService = (IMenuCommandService)await package.GetServiceAsync(typeof(IMenuCommandService));
+            IMenuCommandService commandService = (IMenuCommandService)await package.GetServiceAsync(typeof(IMenuCommandService));
             Assumes.Present(commandService);
 
-            var menuCommandID = new CommandID(PackageGuids.guidRegistryEplorerPackageCmdSet, PackageIds.ShowRegistryExplorerId);
-            var menuItem = new MenuCommand((sender, e) => Execute(package, sender, e), menuCommandID);
+            CommandID menuCommandID = new CommandID(PackageGuids.guidRegistryEplorerPackageCmdSet, PackageIds.ShowRegistryExplorerId);
+            MenuCommand menuItem = new MenuCommand((sender, e) => Execute(package, sender, e), menuCommandID);
             commandService.AddCommand(menuItem);
         }
 

--- a/src/Commands/ShowRegistryExplorer.cs
+++ b/src/Commands/ShowRegistryExplorer.cs
@@ -26,9 +26,9 @@ namespace RegistryExplorer
             package.JoinableTaskFactory.RunAsync(async () =>
             {
                 ToolWindowPane window = await package.ShowToolWindowAsync(
-                    typeof(RegistryExplorerWindow),
-                    0,
-                    create: true,
+                    toolWindowType   : typeof(RegistryExplorerWindow),
+                    id               : 0,
+                    create           : true,
                     cancellationToken: package.DisposalToken);
             });
         }

--- a/src/RegistryEplorerPackage.cs
+++ b/src/RegistryEplorerPackage.cs
@@ -18,7 +18,7 @@ namespace RegistryExplorer
     {
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             await ShowRegistryExplorer.InitializeAsync(this);
         }
 
@@ -44,7 +44,7 @@ namespace RegistryExplorer
 
         protected override Task<object> InitializeToolWindowAsync(Type toolWindowType, int id, CancellationToken cancellationToken)
         {
-            RegistryKey[] keys = new[] { UserRegistryRoot, ApplicationRegistryRoot };
+            RegistryKey[] keys = new[] { this.UserRegistryRoot, this.ApplicationRegistryRoot };
             return Task.FromResult<object>(keys);
         }
     }

--- a/src/RegistryExplorer.csproj
+++ b/src/RegistryExplorer.csproj
@@ -80,6 +80,7 @@
     <Content Include="source.extension.ico">
       <DependentUpon>source.extension.vsixmanifest</DependentUpon>
     </Content>
+    <None Include=".editorconfig" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
       <Generator>VsixManifestGenerator</Generator>

--- a/src/RegistryExplorer.csproj
+++ b/src/RegistryExplorer.csproj
@@ -27,6 +27,7 @@
     <AssemblyName>RegistryExplorer</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <LangVersion>7.3</LangVersion>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>

--- a/src/ToolWindow/RegistryExplorerControl.xaml
+++ b/src/ToolWindow/RegistryExplorerControl.xaml
@@ -1,21 +1,31 @@
-﻿<UserControl x:Class="RegistryExplorer.ToolWindow.RegistryExplorerControl"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:RegistryExplorer.ToolWindow"
-             xmlns:platformUI="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
-             mc:Ignorable="d" 
-             local:VsTheme.UseVsTheme="true"
-             d:DesignHeight="450" d:DesignWidth="800">
+﻿<UserControl
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+    xmlns:local="clr-namespace:RegistryExplorer.ToolWindow"
+    xmlns:platformUI="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+    
+    x:Class="RegistryExplorer.ToolWindow.RegistryExplorerControl"
+    
+    mc:Ignorable="d" 
+    local:VsTheme.UseVsTheme="true"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    x:Name="selfControl"
+>
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="50*"></ColumnDefinition>
-            <ColumnDefinition Width="5"></ColumnDefinition>
-            <ColumnDefinition Width="50*"></ColumnDefinition>
+            <!--<ColumnDefinition Width="50*"/>-->
+            <ColumnDefinition Width="350"/>
+            <ColumnDefinition Width="5"/>
+            <ColumnDefinition Width="50*"/>
         </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
-        <TreeView Name="tree" Grid.Column="0" Margin="0" BorderThickness="0">
+        <TreeView Name="tree" Grid.Column="0" Grid.RowSpan="2" Margin="0" BorderThickness="0">
             <TreeView.ItemContainerStyle>
                 <Style TargetType="{x:Type TreeViewItem}">
                     <Setter Property="KeyboardNavigation.AcceptsReturn" Value="True" />
@@ -30,6 +40,21 @@
                                         </Style>
                                     </MenuItem.Style>
                                 </MenuItem>
+								<MenuItem Header="Search key">
+									<MenuItem.Style>
+										<Style TargetType="MenuItem">
+											<EventSetter Event="Click" Handler="Search_Click"/>
+										</Style>
+									</MenuItem.Style>
+								</MenuItem>
+                                <MenuItem Header="Export key" Visibility="Collapsed">
+                                    <!-- Just an idea for later... -->
+                                    <MenuItem.Style>
+                                        <Style TargetType="MenuItem">
+                                            <EventSetter Event="Click" Handler="Search_Click"/>
+                                        </Style>
+                                    </MenuItem.Style>
+                                </MenuItem>
                             </ContextMenu>
                         </Setter.Value>
                     </Setter>
@@ -37,15 +62,109 @@
             </TreeView.ItemContainerStyle>
         </TreeView>
 
-        <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" />
+        <GridSplitter Grid.Column="1" Grid.RowSpan="2" Width="5" HorizontalAlignment="Stretch" />
 
-        <DataGrid Name="values" Grid.Column="2" AutoGenerateColumns="false" Background="{DynamicResource {x:Static platformUI:EnvironmentColors.BrandedUIBackgroundBrushKey}}" BorderThickness="0" Margin="0" SelectionUnit="Cell" CanUserReorderColumns="False" AlternatingRowBackground="#FFEDEDED" HorizontalGridLinesBrush="Transparent" VerticalGridLinesBrush="Transparent" RowHeaderWidth="0">
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="Name" IsReadOnly="True" Binding="{Binding Path=Name}" />
-                <DataGridTextColumn Header="Type" IsReadOnly="True"  Binding="{Binding Path=Type}" />
-                <DataGridTextColumn Header="Value" IsReadOnly="True"  Binding="{Binding Path=Value}"/>
-            </DataGrid.Columns>
-        </DataGrid>
+        <Grid Grid.Column="2">
+            <Grid.RowDefinitions>
+                <!-- Row 0: currentKeyPath -->
+                <RowDefinition Height="Auto"/>
+                <!-- Row 1: Search controls -->
+                <RowDefinition Height="Auto"/>
+                <!-- Row 2: `values` <DataGrid> -->
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" x:Name="currentKeyPath" Margin="7,3" />
+
+            <Grid Grid.Row="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="Search" Margin="7,3" />
+
+                <TextBox Grid.Column="1" VerticalAlignment="Center" x:Name="searchTerms" KeyDown="searchTerms_KeyDown" />
+
+                <StackPanel Orientation="Horizontal" Grid.Column="2" VerticalAlignment="Center">
+
+                    <Border VerticalAlignment="Center" BorderThickness="1" BorderBrush="{DynamicResource {x:Static platformUI:EnvironmentColors.PanelSubGroupSeparatorBrushKey}}" CornerRadius="3" Margin="3,0">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <CheckBox Content="Case sensitive" Margin="3" VerticalAlignment="Center" x:Name="searchCaseSensitive" />
+                        </StackPanel>
+                    </Border>
+
+                    <Border VerticalAlignment="Center" BorderThickness="1" BorderBrush="{DynamicResource {x:Static platformUI:EnvironmentColors.PanelSubGroupSeparatorBrushKey}}" CornerRadius="3" Margin="3,0">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <RadioButton Content="AND"         Margin="3" VerticalAlignment="Center" GroupName="SearchOp" x:Name="searchOpAnd" IsChecked="True"  />
+                            <RadioButton Content="OR"          Margin="3" VerticalAlignment="Center" GroupName="SearchOp" x:Name="searchOpOr" />
+                        </StackPanel>
+                    </Border>
+
+                    <Border VerticalAlignment="Center" BorderThickness="1" BorderBrush="{DynamicResource {x:Static platformUI:EnvironmentColors.PanelSubGroupSeparatorBrushKey}}" CornerRadius="3" Margin="3,0">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <RadioButton Content="All keys"    Margin="3" VerticalAlignment="Center" GroupName="SearchScope" x:Name="searchAllRad" IsChecked="True"  />
+                            <RadioButton Content="Current key" Margin="3" VerticalAlignment="Center" GroupName="SearchScope" x:Name="searchCurrentRad" />
+                        </StackPanel>
+                    </Border>
+
+                    <Button      Content="Search"      Margin="3" VerticalAlignment="Center" Click="StartSearch_Click" />
+                    <Button      Content="Close"       Margin="3" VerticalAlignment="Center" Click="CloseSearch_Click" Visibility="Collapsed" />
+                </StackPanel>
+
+            </Grid>
+
+            <DataGrid
+                Name="values"
+                Grid.Column="2"
+                Grid.Row="2"
+            
+                AutoGenerateColumns="false"
+                Background="{DynamicResource {x:Static platformUI:EnvironmentColors.BrandedUIBackgroundBrushKey}}"
+                BorderThickness="0"
+                Margin="0"
+                SelectionUnit="Cell"
+                CanUserReorderColumns="False"
+                AlternatingRowBackground="#FFEDEDED"
+                HorizontalGridLinesBrush="Transparent"
+                VerticalGridLinesBrush="Transparent"
+                HeadersVisibility="Column"
+            >
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Name"   IsReadOnly="True" Binding="{Binding Path=Name}"   />
+                    <DataGridTextColumn Header="Length" IsReadOnly="True" Binding="{Binding Path=Length}">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="HorizontalAlignment" Value="Right" />
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                    <DataGridTextColumn Header="Type"   IsReadOnly="True" Binding="{Binding Path=Type}"   />
+                    <DataGridTextColumn Header="Value"  IsReadOnly="True" Binding="{Binding Path=Value}">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style>
+                                <Setter Property="TextBlock.TextWrapping" Value="Wrap" />
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
+                </DataGrid.Columns>
+                <DataGrid.GroupStyle>
+                    <GroupStyle>
+                        <GroupStyle.HeaderTemplate>
+                            <ItemContainerTemplate>
+                                <TextBlock Text="{Binding Name}" FontWeight="Bold" Margin="3" Cursor="Hand">
+                                    <TextBlock.InputBindings>
+                                        <MouseBinding Command="{Binding GoToRegistryKeyCommand, ElementName=selfControl}" CommandParameter="{Binding Name}" MouseAction="LeftClick" />
+                                    </TextBlock.InputBindings>
+                                </TextBlock>
+                            </ItemContainerTemplate>
+                        </GroupStyle.HeaderTemplate>
+                    </GroupStyle>
+                </DataGrid.GroupStyle>
+            </DataGrid>
+
+        </Grid>
 
     </Grid>
 </UserControl>

--- a/src/ToolWindow/RegistryExplorerControl.xaml
+++ b/src/ToolWindow/RegistryExplorerControl.xaml
@@ -40,13 +40,13 @@
                                         </Style>
                                     </MenuItem.Style>
                                 </MenuItem>
-								<MenuItem Header="Search key">
-									<MenuItem.Style>
-										<Style TargetType="MenuItem">
-											<EventSetter Event="Click" Handler="Search_Click"/>
-										</Style>
-									</MenuItem.Style>
-								</MenuItem>
+                                <MenuItem Header="Search key">
+                                    <MenuItem.Style>
+                                        <Style TargetType="MenuItem">
+                                            <EventSetter Event="Click" Handler="Search_Click"/>
+                                        </Style>
+                                    </MenuItem.Style>
+                                </MenuItem>
                                 <MenuItem Header="Export key" Visibility="Collapsed">
                                     <!-- Just an idea for later... -->
                                     <MenuItem.Style>

--- a/src/ToolWindow/RegistryExplorerControl.xaml.cs
+++ b/src/ToolWindow/RegistryExplorerControl.xaml.cs
@@ -1,40 +1,88 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Input;
+
 using Microsoft.Win32;
 
 namespace RegistryExplorer.ToolWindow
 {
     public partial class RegistryExplorerControl : UserControl
     {
-        private RegistryKey[] _keys;
-        private object _defaultValue = new { Name = "(Default)", Type = RegistryValueKind.String, Value = "(value not set)" };
+        private readonly RegistryKey[] keys;
+        
+        private static readonly object _defaultValue = new { Name = "(Default)", Length = "", Type = RegistryValueKind.String, Value = "(value not set)" };
+
+        private readonly TreeViewItem searchTreeItem = new TreeViewItem()
+        {
+            Header = "Search"
+        };
 
         public RegistryExplorerControl(RegistryKey[] keys)
         {
-            this._keys = keys;
-            Loaded += this.OnLoaded;
+            this.keys = keys;
+
+            this.searchTreeItem.Selected += this.SearchTreeItem_Selected;
+            
+            this.GoToRegistryKeyCommand = new GoToRegistryKeyCommandImpl(ctrl: this);
+
+            this.Loaded += this.OnLoaded;
+
             RegistryTreeItem.ItemSelected += this.OnItemSelected;
+
             this.InitializeComponent();
         }
 
-        private void Refresh_Click(object sender, System.Windows.RoutedEventArgs e)
+        private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            this.tree.Items.Clear();
+
+            _ = this.tree.Items.Add(this.searchTreeItem);
+
+            foreach (RegistryKey key in this.keys)
+            {
+                RegistryTreeItem item = new RegistryTreeItem(key, populateImmediateChildren: true);
+
+                _ = this.tree.Items.Add(item);
+
+                if (this.tree.SelectedItem == null)
+                {
+                    item.IsSelected = true;
+                }
+            }
+
+            _ = this.Focus();
+        }
+
+        private async void Refresh_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             if (this.tree.SelectedItem is RegistryTreeItem selected)
             {
-                selected.Refresh(selected);
-                this.UpdateDetailsGridAsync(selected).ConfigureAwait(false);
+                selected.Refresh(selected, expand: true);
+                await this.UpdateDetailsGridAsync(selected);
             }
         }
 
-        private void OnItemSelected(object sender, RegistryTreeItem e)
+        private async void OnItemSelected(object sender, RegistryTreeItem e)
         {
-            this.UpdateDetailsGridAsync(e).ConfigureAwait(false);
+            await this.UpdateDetailsGridAsync(e);
         }
 
         private async Task UpdateDetailsGridAsync(RegistryTreeItem item)
         {
+            if (this.values.ItemsSource == this.lastSearchResults)
+            {
+                this.values.ItemsSource = null;
+            }
+
+            this.currentKeyPath.Text = item.Key.Name;
+
             this.values.Items.Clear();
 
             // Wait a bit in case the user moved to a different tree node quickly
@@ -46,59 +94,354 @@ namespace RegistryExplorer.ToolWindow
                 return;
             }
 
-            if (item.Key.ValueCount > 0)
+            this.ShowRegistryKey(item.Key);
+        }
+
+        private RegistryKey lastKey;
+
+        private void ShowRegistryKey(RegistryKey key)
+        {
+            if (this.values.ItemsSource == this.lastSearchResults)
             {
-                IOrderedEnumerable<string> names = item.Key.GetValueNames().OrderBy(x => x);
+                this.values.ItemsSource = null;
+            }
 
-                using (this.Dispatcher.DisableProcessing())
+            if (key.ValueCount == 0)
+            {
+                _ = this.values.Items.Add(_defaultValue);
+                this.lastKey = key;
+                return;
+            }
+
+            IOrderedEnumerable<string> names = key.GetValueNames().OrderBy(x => x);
+
+            using (this.Dispatcher.DisableProcessing())
+            {
+                foreach (string name in names)
                 {
-                    foreach (string name in names)
+                    RegistryValueKind kind = key.GetValueKind(name);
+                    object value = key.GetValue(name);
+                    value = FormatRegKeyValue(kind, value, out string length);
+
+                    string displayName = string.IsNullOrEmpty(name) ? "(Default)" : name;
+
+                    _ = this.values.Items.Add(new { Name = displayName, Length = length, Type = kind, Value = value });
+                }
+            }
+
+            this.lastKey = key;
+        }
+
+        internal static object FormatRegKeyValue(RegistryValueKind kind, object value, out string length)
+        {
+            if (kind == RegistryValueKind.Binary && value is byte[] bytes)
+            {
+                length = string.Format("{0:N0} bytes", bytes.Length);
+                return BitConverter.ToString(bytes).Replace("-", " ");
+            }
+            else if (kind == RegistryValueKind.DWord && value is int dword)
+            {
+                length = "";
+                return string.Format("0x{0:X} ({0:d})", dword);
+            }
+            else if (kind == RegistryValueKind.QWord && value is long qword)
+            {
+                length = "";
+                return string.Format("0x{0:X} ({0:d})", qword).ToLowerInvariant();
+            }
+            else if(value is string str)
+            {
+                length = string.Format("{0:N0} chars", str.Length);
+                return value;
+            }
+            else if(value is null)
+            {
+                length = "";
+                return "(null)";
+            }
+            else
+            {
+                length = "";
+                return value;
+            }
+        }
+
+        #region Search
+
+        private ListCollectionView lastSearchResults; 
+
+        private void SearchTreeItem_Selected(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (this.lastSearchResults != null)
+            {
+                this.values.ItemsSource = this.lastSearchResults;
+            }
+        }
+
+        /// <summary>This is the event-handler for the tree node context-menu's Search command.</summary>
+        private async void Search_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (this.tree.SelectedItem is RegistryTreeItem selected)
+            {
+                this.searchCurrentRad.IsChecked = true;
+                selected.Refresh(selected, expand: true);
+                await this.UpdateDetailsGridAsync(selected);
+            }
+        }
+
+        private async void searchTerms_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                await this.StartSearchAsync();
+            }
+        }
+
+        /// <summary>This is the event-handler for the search bar button.</summary>
+        private async void StartSearch_Click(object sender, RoutedEventArgs e)
+        {
+            await this.StartSearchAsync();
+        }
+
+        private async Task StartSearchAsync()
+        {
+            IReadOnlyCollection<string> terms = GetSearchTerms(this.searchTerms.Text);
+            if (terms.Count == 0) return;
+
+            bool allTerms      = this.searchOpAnd.IsChecked == true;
+            bool caseSensitive = this.searchCaseSensitive.IsChecked == true;
+
+            IReadOnlyCollection<RegistryTreeItem> fromItems = this.GetSearchFrom();
+            
+            if (fromItems.Count > 0)
+            {
+                this.IsEnabled = false;
+                this.Cursor = Cursors.Wait;
+                try
+                {
+                    // Preload entire tree in the UI thread:
+                    foreach (RegistryTreeItem item in fromItems)
                     {
-                        RegistryValueKind type = item.Key.GetValueKind(name);
-                        object value = item.Key.GetValue(name);
-
-                        if (type == RegistryValueKind.Binary && value is byte[] bytes)
-                        {
-                            value = BitConverter.ToString(bytes).Replace("-", " ");
-                        }
-                        else if (type == RegistryValueKind.DWord && value is int dword)
-                        {
-                            value = string.Format("0x{0:X}", dword) + $" ({dword})";
-                        }
-                        else if (type == RegistryValueKind.QWord && value is long qword)
-                        {
-                            value = string.Format("0x{0:X}", qword).ToLowerInvariant() + $" ({qword})";
-                        }
-
-                        string displayName = string.IsNullOrEmpty(name) ? "(Default)" : name;
-
-                        this.values.Items.Add(new { Name = displayName, Type = type, Value = value });
+                        RegistryTreeItem.Prepopulate(this.Dispatcher, item);
                     }
+
+                     // Do the actual search in a background thread:
+                    Task<List<SearchResult>> task = Task.Run(() => this.DoSearch(allTerms, caseSensitive, terms, fromItems));
+
+                    List<SearchResult> results = await task;
+
+                    this.ShowSearchResults(results);
+                }
+                finally
+                {
+                    this.Cursor = null;
+                    this.IsEnabled = true;
+                }
+            }
+        }
+
+        private static IReadOnlyCollection<string> GetSearchTerms(string userInput)
+        {
+            if (string.IsNullOrWhiteSpace(userInput)) return Array.Empty<string>();
+            if (userInput.IndexOf('"') < 0) return userInput.Split(separator: (char[])null, options: StringSplitOptions.RemoveEmptyEntries);
+
+            List<string> terms = new List<string>();
+
+            bool inQuotes = false;
+            StringBuilder sb = new StringBuilder();
+
+            foreach (char c in userInput)
+            {
+                if (inQuotes)
+                {
+                    if (c == '"')
+                    {
+                        if (sb.Length > 0)
+                        {
+                            terms.Add(sb.ToString());
+                            sb.Length = 0;
+                        }
+                        inQuotes = false;
+                    }
+                    else
+                    {
+                        _ = sb.Append(c);
+                    }
+                }
+                else
+                {
+                    if (c == '"')
+                    {
+                        inQuotes = true;
+                    }
+                    else
+                    {
+                        if( Char.IsWhiteSpace(c))
+                        {
+                            if (sb.Length > 0)
+                            {
+                                terms.Add(sb.ToString());
+                                sb.Length = 0;
+                            }
+                        }
+                        else
+                        {
+                            _ = sb.Append(c);
+                        }
+                    }
+                }
+            }
+
+            if(sb.Length > 0)
+            {
+                terms.Add(sb.ToString());
+                sb.Length = 0;
+            }
+
+            return terms;
+        }
+
+        private IReadOnlyCollection<RegistryTreeItem> GetSearchFrom()
+        {
+            if (this.searchAllRad.IsChecked == true)
+            {
+                return this.tree.Items.OfType<RegistryTreeItem>().ToList();
+            }
+            else if (this.searchCurrentRad.IsChecked == true)
+            {
+                if (this.tree.SelectedItem is RegistryTreeItem currentItem)
+                {
+                    return new[] { currentItem };
+                }
+                else
+                {
+                    return Array.Empty<RegistryTreeItem>();
                 }
             }
             else
             {
-                this.values.Items.Add(this._defaultValue);
+                return Array.Empty<RegistryTreeItem>();
             }
         }
 
-        private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
+        private void CloseSearch_Click(object sender, System.Windows.RoutedEventArgs e)
         {
-            this.tree.Items.Clear();
-
-            foreach (RegistryKey key in this._keys)
+            if(this.lastKey != null)
             {
-                RegistryTreeItem item = new RegistryTreeItem(key, true);
+                this.ShowRegistryKey(this.lastKey);
+            }
+        }
 
-                this.tree.Items.Add(item);
+        private List<SearchResult> DoSearch(bool allTerms, bool caseSensitive, IReadOnlyCollection<string> terms, IReadOnlyCollection<RegistryTreeItem> fromItems)
+        {
+            List<SearchResult> searchResults = new List<SearchResult>();
 
-                if (this.tree.SelectedItem == null)
+            Stopwatch sw = Stopwatch.StartNew();
+
+            foreach (RegistryTreeItem item in fromItems)
+            {
+                item.Search(allTerms, caseSensitive, terms, searchResults);
+            }
+
+            TimeSpan searchTime = sw.Elapsed;
+
+            return searchResults;
+        }
+
+        private void ShowSearchResults(List<SearchResult> searchResults)
+        {
+            this.values.Items.Clear();
+
+            this.lastSearchResults = new ListCollectionView(searchResults)
+            {
+                GroupDescriptions =
                 {
-                    item.IsSelected = true;
+                    new PropertyGroupDescription(propertyName: nameof(SearchResult.KeyPath))
+                }
+            };
+
+            this.values.ItemsSource = this.lastSearchResults;
+        }
+
+        #endregion
+
+        #region Go-to-Key
+
+        public ICommand GoToRegistryKeyCommand { get; }
+
+        private class GoToRegistryKeyCommandImpl : ICommand
+        {
+            private readonly RegistryExplorerControl ctrl;
+
+            public GoToRegistryKeyCommandImpl(RegistryExplorerControl ctrl)
+            {
+                this.ctrl = ctrl ?? throw new ArgumentNullException(nameof(ctrl));
+            }
+
+            public bool CanExecute(object parameter) => true;
+
+            public void Execute(object parameter)
+            {
+                if (parameter is string keyPath)
+                {
+                    this.ctrl.GoToKeyPath(keyPath);
                 }
             }
 
-            this.Focus();
+            public event EventHandler CanExecuteChanged;
         }
+
+        public void GoToKeyPath(string path)
+        {
+            path = path.TrimEnd('\\');
+
+            foreach (RegistryTreeItem rootTreeNode in this.tree.Items.OfType<RegistryTreeItem>())
+            {
+                RegistryTreeItem exactMatch = null;
+                if (rootTreeNode.TryGetItemForPath(absolutePathWithoutTrailingSlash: path, ref exactMatch) && exactMatch != null)
+                {
+                    RegistryTreeItem node = exactMatch;
+                    while (node != null)
+                    {
+                        node.IsExpanded = true;
+                        node = node.Parent as RegistryTreeItem;
+                    }
+
+                    exactMatch.IsSelected = true; // <-- This triggers `OnItemSelected`.
+//                  exactMatch.IsExpanded = true; // Hmm, this isn't recursive, is it?
+
+                    break;
+                }
+            }
+        }
+
+        #endregion
+    }
+
+    public class SearchResult
+    {
+        public SearchResult(
+            string            keyPath,
+            string            valueName,
+            RegistryValueKind kind,
+            object            value
+        )
+        {
+            value = RegistryExplorerControl.FormatRegKeyValue(kind, value, out string length);
+
+            this.KeyPath = keyPath   ?? throw new ArgumentNullException(nameof(value));
+            this.Name    = valueName ?? throw new ArgumentNullException(nameof(value));
+            this.Length  = length;
+            this.Type    = kind;
+            this.Value   = value;
+        }
+
+        // Same member names as the anonymous objects used for normal key items, so the <DataGrid> definition can be reused:
+
+        public string            KeyPath { get; }
+        public string            Name    { get; }
+        public string            Length  { get; }
+        public RegistryValueKind Type    { get; }
+        public object            Value   { get; }
     }
 }

--- a/src/ToolWindow/RegistryExplorerControl.xaml.cs
+++ b/src/ToolWindow/RegistryExplorerControl.xaml.cs
@@ -13,35 +13,35 @@ namespace RegistryExplorer.ToolWindow
 
         public RegistryExplorerControl(RegistryKey[] keys)
         {
-            _keys = keys;
-            Loaded += OnLoaded;
-            RegistryTreeItem.ItemSelected += OnItemSelected;
-            InitializeComponent();
+            this._keys = keys;
+            Loaded += this.OnLoaded;
+            RegistryTreeItem.ItemSelected += this.OnItemSelected;
+            this.InitializeComponent();
         }
 
         private void Refresh_Click(object sender, System.Windows.RoutedEventArgs e)
         {
-            if (tree.SelectedItem is RegistryTreeItem selected)
+            if (this.tree.SelectedItem is RegistryTreeItem selected)
             {
                 selected.Refresh(selected);
-                UpdateDetailsGridAsync(selected).ConfigureAwait(false);
+                this.UpdateDetailsGridAsync(selected).ConfigureAwait(false);
             }
         }
 
         private void OnItemSelected(object sender, RegistryTreeItem e)
         {
-            UpdateDetailsGridAsync(e).ConfigureAwait(false);
+            this.UpdateDetailsGridAsync(e).ConfigureAwait(false);
         }
 
         private async Task UpdateDetailsGridAsync(RegistryTreeItem item)
         {
-            values.Items.Clear();
+            this.values.Items.Clear();
 
             // Wait a bit in case the user moved to a different tree node quickly
             await Task.Delay(200);
 
             // Another tree node was selected in the meantime.
-            if (item != tree.SelectedItem)
+            if (item != this.tree.SelectedItem)
             {
                 return;
             }
@@ -50,7 +50,7 @@ namespace RegistryExplorer.ToolWindow
             {
                 IOrderedEnumerable<string> names = item.Key.GetValueNames().OrderBy(x => x);
 
-                using (Dispatcher.DisableProcessing())
+                using (this.Dispatcher.DisableProcessing())
                 {
                     foreach (string name in names)
                     {
@@ -72,33 +72,33 @@ namespace RegistryExplorer.ToolWindow
 
                         string displayName = string.IsNullOrEmpty(name) ? "(Default)" : name;
 
-                        values.Items.Add(new { Name = displayName, Type = type, Value = value });
+                        this.values.Items.Add(new { Name = displayName, Type = type, Value = value });
                     }
                 }
             }
             else
             {
-                values.Items.Add(_defaultValue);
+                this.values.Items.Add(this._defaultValue);
             }
         }
 
         private void OnLoaded(object sender, System.Windows.RoutedEventArgs e)
         {
-            tree.Items.Clear();
+            this.tree.Items.Clear();
 
-            foreach (RegistryKey key in _keys)
+            foreach (RegistryKey key in this._keys)
             {
-                var item = new RegistryTreeItem(key, true);
+                RegistryTreeItem item = new RegistryTreeItem(key, true);
 
-                tree.Items.Add(item);
+                this.tree.Items.Add(item);
 
-                if (tree.SelectedItem == null)
+                if (this.tree.SelectedItem == null)
                 {
                     item.IsSelected = true;
                 }
             }
 
-            Focus();
+            this.Focus();
         }
     }
 }

--- a/src/ToolWindow/RegistryExplorerWindow.cs
+++ b/src/ToolWindow/RegistryExplorerWindow.cs
@@ -14,10 +14,10 @@ namespace RegistryExplorer
 
         public RegistryExplorerWindow(RegistryKey[] keys) : base()
         {
-            Caption = Title;
+            this.Caption = Title;
 
-            var elm = new RegistryExplorerControl(keys);
-            Content = elm;
+            RegistryExplorerControl elm = new RegistryExplorerControl(keys);
+            this.Content = elm;
         }
     }
 }

--- a/src/ToolWindow/RegistryTreeItem.cs
+++ b/src/ToolWindow/RegistryTreeItem.cs
@@ -13,15 +13,15 @@ namespace RegistryExplorer.ToolWindow
     {
         public RegistryTreeItem(RegistryKey key, bool populateImmediateChildren = false)
         {
-            Key = key;
-            Header = Path.GetFileName(key.Name);
+            this.Key = key;
+            this.Header = Path.GetFileName(key.Name);
 
             if (populateImmediateChildren)
             {
-                PopulateNode(this);
+                this.PopulateNode(this);
             }
 
-            SetResourceReference(TextElement.ForegroundProperty, EnvironmentColors.BrandedUITitleBrushKey);
+            this.SetResourceReference(TextElement.ForegroundProperty, EnvironmentColors.BrandedUITitleBrushKey);
         }
 
         public static event EventHandler<RegistryTreeItem> ItemSelected;
@@ -30,25 +30,25 @@ namespace RegistryExplorer.ToolWindow
 
         protected override void OnSelected(RoutedEventArgs e)
         {
-            if (IsSelected)
+            if (this.IsSelected)
             {
-                SetResourceReference(TextElement.ForegroundProperty, EnvironmentColors.SystemHighlightTextBrushKey);
+                this.SetResourceReference(TextElement.ForegroundProperty, EnvironmentColors.SystemHighlightTextBrushKey);
                 ItemSelected?.Invoke(this, this);
             }
         }
 
         protected override void OnUnselected(RoutedEventArgs e)
         {
-            SetResourceReference(TextElement.ForegroundProperty, EnvironmentColors.BrandedUITitleBrushKey);
+            this.SetResourceReference(TextElement.ForegroundProperty, EnvironmentColors.BrandedUITitleBrushKey);
         }
 
         protected override void OnExpanded(RoutedEventArgs e)
         {
-            var item = (RegistryTreeItem)e.Source;
+            RegistryTreeItem item = (RegistryTreeItem)e.Source;
 
             foreach (RegistryTreeItem child in item.Items)
             {
-                PopulateNode(child);
+                this.PopulateNode(child);
             }
         }
         protected override void OnMouseRightButtonUp(MouseButtonEventArgs e)
@@ -61,22 +61,24 @@ namespace RegistryExplorer.ToolWindow
 
         public void Refresh(RegistryTreeItem item)
         {
-            Items.Clear();
-            PopulateNode(item);
+            this.Items.Clear();
+            this.PopulateNode(item);
             item.IsExpanded = true;
         }
 
         private void PopulateNode(RegistryTreeItem item)
         {
             if (item.HasItems || item.Key.SubKeyCount == 0)
+            {
                 return;
+            }
 
-            using (Dispatcher.DisableProcessing())
+            using (this.Dispatcher.DisableProcessing())
             {
                 foreach (string name in item.Key.GetSubKeyNames())
                 {
                     RegistryKey subkey = item.Key.OpenSubKey(name, false);
-                    var child = new RegistryTreeItem(subkey);
+                    RegistryTreeItem child = new RegistryTreeItem(subkey);
 
                     item.Items.Add(child);
                 }

--- a/src/ToolWindow/RegistryTreeItem.cs
+++ b/src/ToolWindow/RegistryTreeItem.cs
@@ -1,9 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Threading;
+
 using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.Win32;
 
@@ -13,12 +18,14 @@ namespace RegistryExplorer.ToolWindow
     {
         public RegistryTreeItem(RegistryKey key, bool populateImmediateChildren = false)
         {
-            this.Key = key;
+            this.Key          = key ?? throw new ArgumentNullException(nameof(key));
+            this.AbsolutePath = key.Name.TrimEnd('\\');
+
             this.Header = Path.GetFileName(key.Name);
 
             if (populateImmediateChildren)
             {
-                this.PopulateNode(this);
+                PopulateNode(this.Dispatcher, item: this);
             }
 
             this.SetResourceReference(TextElement.ForegroundProperty, EnvironmentColors.BrandedUITitleBrushKey);
@@ -27,6 +34,9 @@ namespace RegistryExplorer.ToolWindow
         public static event EventHandler<RegistryTreeItem> ItemSelected;
 
         public RegistryKey Key { get; }
+
+        /// <summary>Absolute registry path of <see cref="Key"/> without any trailing slash.</summary>
+        public string AbsolutePath { get; }
 
         protected override void OnSelected(RoutedEventArgs e)
         {
@@ -48,7 +58,7 @@ namespace RegistryExplorer.ToolWindow
 
             foreach (RegistryTreeItem child in item.Items)
             {
-                this.PopulateNode(child);
+                PopulateNode(this.Dispatcher, item: child);
             }
         }
         protected override void OnMouseRightButtonUp(MouseButtonEventArgs e)
@@ -59,30 +69,225 @@ namespace RegistryExplorer.ToolWindow
             }
         }
 
-        public void Refresh(RegistryTreeItem item)
+        public bool TryGetItemForPath(string absolutePathWithoutTrailingSlash, ref RegistryTreeItem exactMatch)
         {
-            this.Items.Clear();
-            this.PopulateNode(item);
-            item.IsExpanded = true;
+            if (absolutePathWithoutTrailingSlash.StartsWith(this.AbsolutePath, StringComparison.OrdinalIgnoreCase))
+            {
+                if (absolutePathWithoutTrailingSlash.Length == this.AbsolutePath.Length)
+                {
+                    exactMatch = this;
+                    return true;
+                }
+                else
+                {
+                    foreach (RegistryTreeItem child in this.Items)
+                    {
+                        if (absolutePathWithoutTrailingSlash.StartsWith(child.AbsolutePath, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return child.TryGetItemForPath(absolutePathWithoutTrailingSlash, ref exactMatch);
+                        }
+                    }
+
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
         }
 
-        private void PopulateNode(RegistryTreeItem item)
+        public void Refresh(RegistryTreeItem item, bool? expand)
+        {
+            this.Items.Clear();
+            PopulateNode(this.Dispatcher, item);
+            if (expand.HasValue)
+            {
+                item.IsExpanded = expand.Value;
+            }
+        }
+
+        public static void Prepopulate(Dispatcher dispatcher, RegistryTreeItem item)
+        {
+            using (dispatcher.DisableProcessing())
+            {
+                PrepopulateInner(item);
+            }
+        }
+
+        private static void PrepopulateInner(RegistryTreeItem item)
+        {
+            bool alreadyLoadedSelf = item.Items.Count == item.Key.SubKeyCount;
+            if (!alreadyLoadedSelf)
+            {
+                item.Items.Clear();
+                if (item.Key.SubKeyCount > 0)
+                {
+                    foreach (string name in item.Key.GetSubKeyNames())
+                    {
+                        RegistryKey subkey = item.Key.OpenSubKey(name, writable: false);
+                        RegistryTreeItem child = new RegistryTreeItem(subkey);
+
+                        _ = item.Items.Add(child);
+                    }
+                }
+            }
+
+            foreach (RegistryTreeItem child in item.Items)
+            {
+                PrepopulateInner(item: child);
+            }
+        }
+
+        private static void PopulateNode(Dispatcher dispatcher, RegistryTreeItem item)
         {
             if (item.HasItems || item.Key.SubKeyCount == 0)
             {
                 return;
             }
 
-            using (this.Dispatcher.DisableProcessing())
+            using (dispatcher.DisableProcessing())
             {
                 foreach (string name in item.Key.GetSubKeyNames())
                 {
                     RegistryKey subkey = item.Key.OpenSubKey(name, false);
                     RegistryTreeItem child = new RegistryTreeItem(subkey);
 
-                    item.Items.Add(child);
+                    _ = item.Items.Add(child);
                 }
             }
         }
+
+        #region Search
+
+        public void Search(bool allTerms, bool caseSensitive, IReadOnlyCollection<string> terms, List<SearchResult> searchResults)
+        {
+            foreach (string valueName in this.Key.GetValueNames())
+            {
+                RegistryValueKind valueKind = this.Key.GetValueKind(valueName);
+                object            value     = this.Key.GetValue(valueName);
+
+                if (RegKeyValueMatchesTerms(allTerms, caseSensitive, terms, valueName, valueKind, value))
+                {
+                    searchResults.Add(new SearchResult(keyPath: this.Key.Name, valueName, valueKind, value));
+                }
+            }
+
+            //PopulateNode(this.Dispatcher, item: this); // Commented-out due to dispatcher thread issues.
+
+            foreach (object child in this.Items)
+            {
+                if (child is RegistryTreeItem regTreeItem)
+                {
+                    regTreeItem.Search(allTerms, caseSensitive, terms, searchResults);
+                }
+            }
+        }
+
+        private static bool RegKeyValueMatchesTerms(bool allTerms, bool caseSensitive, IReadOnlyCollection<string> terms, string valueName, RegistryValueKind valueKind, object value)
+        {
+            StringComparison sc = caseSensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+            if (allTerms) // aka AND
+            {
+                foreach (string term in terms)
+                {
+                    long? integerTerm = Int64.TryParse(term, NumberStyles.Any, CultureInfo.CurrentCulture, out long v) ? v : (long?)null;
+
+                    if (!RegKeyValueMatchesTerm(sc, term, integerTerm, valueName, valueKind, value))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            else // i.e. any-terms, aka OR
+            {
+                foreach (string term in terms)
+                {
+                    long? integerTerm = Int64.TryParse(term, NumberStyles.Any, CultureInfo.CurrentCulture, out long v) ? v : (long?)null;
+
+                    if (RegKeyValueMatchesTerm(sc, term, integerTerm, valueName, valueKind, value))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        private static bool RegKeyValueMatchesTerm(StringComparison sc, string term, long? integerTerm, string valueName, RegistryValueKind valueKind, object value)
+        {
+            if (valueName.IndexOf(term, sc) > 0) return true;
+
+            switch (valueKind)
+            {
+                case RegistryValueKind.String:
+                case RegistryValueKind.ExpandString:
+                    {
+                        string valueStr = value.ToString();
+                        return valueStr.IndexOf(term, sc) > 0;
+                    }
+                case RegistryValueKind.Binary:
+                    {
+                        byte[] bytes = (byte[])value;
+
+                        // Try UTF-8:
+                        try
+                        {
+                            string text = Encoding.UTF8.GetString(bytes);
+                            if (text.IndexOf(term, sc) > 0) return true;
+                        }
+                        catch
+                        {
+                        }
+
+                        // Try UTF-16LE:
+                        try
+                        {
+                            string text = Encoding.Unicode.GetString(bytes);
+                            if (text.IndexOf(term, sc) > 0) return true;
+                        }
+                        catch
+                        {
+                        }
+
+                        return false;
+                    }
+                case RegistryValueKind.DWord:
+                    if (integerTerm.HasValue)
+                    {
+                        int valueInt32 = (int)value;
+                        return integerTerm.Value == valueInt32;
+                    }
+                    return false;
+                    
+                 case RegistryValueKind.QWord:
+                    if (integerTerm.HasValue)
+                    {
+                        long valueInt64 = (long)value;
+                        return integerTerm.Value == valueInt64;
+                    }
+                    return false;
+
+                case RegistryValueKind.MultiString:
+                    {
+                        string[] values = (string[])value;
+                        foreach (string valueStr in values)
+                        {
+                            if(valueStr.IndexOf(term, sc) > 0) return true;
+                        }
+                        return false;
+                    }
+                case RegistryValueKind.None:
+                case RegistryValueKind.Unknown:
+                default:
+                    return false;
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/ToolWindow/VsTheme.cs
+++ b/src/ToolWindow/VsTheme.cs
@@ -45,12 +45,12 @@ namespace RegistryExplorer.ToolWindow
 
         private static ResourceDictionary BuildThemeResources()
         {
-            var allResources = new ResourceDictionary();
+            ResourceDictionary allResources = new ResourceDictionary();
 
             try
             {
-                var shellResources = (ResourceDictionary)Application.LoadComponent(new Uri("Microsoft.VisualStudio.Platform.WindowManagement;component/Themes/ThemedDialogDefaultStyles.xaml", UriKind.Relative));
-                var scrollStyleContainer = (ResourceDictionary)Application.LoadComponent(new Uri("Microsoft.VisualStudio.Shell.UI.Internal;component/Styles/ScrollBarStyle.xaml", UriKind.Relative));
+                ResourceDictionary shellResources = (ResourceDictionary)Application.LoadComponent(new Uri("Microsoft.VisualStudio.Platform.WindowManagement;component/Themes/ThemedDialogDefaultStyles.xaml", UriKind.Relative));
+                ResourceDictionary scrollStyleContainer = (ResourceDictionary)Application.LoadComponent(new Uri("Microsoft.VisualStudio.Shell.UI.Internal;component/Styles/ScrollBarStyle.xaml", UriKind.Relative));
                 allResources.MergedDictionaries.Add(shellResources);
                 allResources.MergedDictionaries.Add(scrollStyleContainer);
                 allResources[typeof(ScrollViewer)] = new Style
@@ -95,7 +95,7 @@ namespace RegistryExplorer.ToolWindow
             }
             else if (control.Resources != ThemeResources)
             {
-                var d = new ResourceDictionary();
+                ResourceDictionary d = new ResourceDictionary();
                 d.MergedDictionaries.Add(ThemeResources);
                 d.MergedDictionaries.Add(control.Resources);
                 control.Resources = null;


### PR DESCRIPTION
I've added a simple(-ish) search feature to this extension.

This is a first-draft - it's a bit rough around the edges, especially w.r.t the Search tree-node item and cycling between registry-key-nodes and displaying search results. I'm also unsure about if `RegistryTreeItem` objects should really be removed with `Items.Clear()` without disposing of their owned `RegistryKey` objects.

![image](https://user-images.githubusercontent.com/1693078/121802742-dae69200-cbf2-11eb-9610-765420782aeb.png)
